### PR TITLE
[janitor] github.com/epfl-idevelop → github.com/epfl-si #25 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 Epfl theme (Wordpress)
 ===
  * Based on [*_s* theme (underscores)](https://underscores.me/)
- * Implements the [elements](https://github.com/epfl-idevelop/elements) styleguide
+ * Implements the [elements](https://github.com/epfl-si/elements) styleguide
  * Uses shortcodes to display special content served by EPFL APIs.
 
 ## Requirements
-  * production build files of [elements](https://github.com/epfl-idevelop/elements) located in `/assets` (create a new version if needed)
+  * production build files of [elements](https://github.com/epfl-si/elements) located in `/assets` (create a new version if needed)
   * composer
 
 ## How to install
@@ -15,7 +15,7 @@ Epfl theme (Wordpress)
 
 ## Build a new release
 ### Recovering the last version of the styleguide
-  - Clone element repository `git clone git@github.com:epfl-idevelop/elements.git`
+  - Clone element repository `git clone git@github.com:epfl-si/elements.git`
   - `git checkout `
   - Go on master branch `git checkout master`
   - update `git pull`
@@ -73,7 +73,7 @@ Hooks and filters directory? [/home/greg/workspace-idevelop/epfl-theme/.git/hook
   - commit them in a "Bump version" commit `git commit -am "Bump version"`
   - finish the release: `git flow release finish x.x.x -p -m "x.x.x"`
   - Push all the changes `git push`, `git checkout master && git push` and `git push --tags`
-  - head over this repo on github, on the **release** tab (or go directly using https://github.com/epfl-idevelop/wp-theme-2018/releases/edit/x.x.x)
+  - head over this repo on github, on the **release** tab (or go directly using https://github.com/epfl-si/wp-theme-2018/releases/edit/x.x.x)
   - go to **Draft a new release**
   - choose the release number you just created, insert the changelog informations into the release description
   - Publish the release

--- a/wp-theme-light/footer_fr.php
+++ b/wp-theme-light/footer_fr.php
@@ -40,7 +40,7 @@
         
 <div class="footer-legal">
   <div class="footer-legal-links">
-    <a href="https://epfl-idevelop.github.io/elements/#/doc/accessibility.html">Accessibilité</a>
+    <a href="https://epfl-si.github.io/elements/#/doc/accessibility.html">Accessibilité</a>
     <a href="https://www.epfl.ch/about/overview/fr/reglements-et-directives/">Mentions légales</a>
   </div>
   <div>


### PR DESCRIPTION
Following the rename of the epfl-idevelop GitHub organization to epfl-si today, we want to update all pointers (despite the old addresses still working for now).