### PR TITLE
Revert "Add "back to top" button markup to the WP theme"

### DIFF
--- a/wp-theme-2018/footer_en.php
+++ b/wp-theme-2018/footer_en.php
@@ -264,10 +264,3 @@
 </div>
 
 </footer>
-
-<button id="back-to-top" class="btn btn-primary btn-back-to-top">
-  <span class="sr-only">Back to top</span>
-  <svg class="icon" aria-hidden="true">
-    <use xlink:href="#icon-chevron-top"></use>
-  </svg>
-</button>

--- a/wp-theme-2018/footer_fr.php
+++ b/wp-theme-2018/footer_fr.php
@@ -264,10 +264,3 @@
 </div>
 
 </footer>
-
-<button id="back-to-top" class="btn btn-primary btn-back-to-top">
-  <span class="sr-only">Back to top</span>
-  <svg class="icon" aria-hidden="true">
-    <use xlink:href="#icon-chevron-top"></use>
-  </svg>
-</button>


### PR DESCRIPTION
Reverting epfl-si/wp-theme-2018#257 as the "back to top" button is taking too much place.