### PR TITLE
Set gallery drawer for gutenberg compatiblities; drop shortcode gallery support

### DIFF
--- a/wp-theme-2018/inc/media-gallery.php
+++ b/wp-theme-2018/inc/media-gallery.php
@@ -5,17 +5,22 @@
  * @package epfl
  */
 
-add_filter( 'post_gallery', 'epflGallery', 10, 3 );
+function epfl_gallery_block($attr) {
 
-function epflGallery($output = '', $attr, $instance){
+    /* If a gallery block is added but never configured, this function will be called with $attr equal to an empty array...
+        so there are PHP Warnings in the logs because we are trying to access 'ids' key. */
+    if(!array_key_exists('ids', $attr)) return '';
+
+    $output = '';
+    $instance=md5(implode(',', $attr) . rand());
 
     /* We recover posts info but... not in the same order as the one given in parameters ($attr['ids'])*/
     $posts = get_posts(array('include' => $attr['ids'],'post_type' => 'attachment'));
 
-    $output = '<div id="my-gallery-'.$instance.'" class="gallery gallery-main mt-4">';
+    $output = '<div id="my-gallery-' . $instance . '" class="gallery gallery-main mt-4">';
 
     /* We go through given image order */
-    foreach(explode(',', $attr['ids']) as $post_id)
+    foreach($attr['ids'] as $post_id)
     {
         /* We now look for returned matching image and add it to display */
         foreach($posts as $imagePost)
@@ -45,14 +50,12 @@ function epflGallery($output = '', $attr, $instance){
         }
     }
 
-
-
     $output .= "</div>";
 
     $output .= '<div class="gallery-nav mb-3" data-gallery="my-gallery-'.$instance.'" aria-hidden="true">';
 
     /* We go through given image order */
-    foreach(explode(',', $attr['ids']) as $post_id)
+    foreach($attr['ids'] as $post_id)
     {
         /* We now look for returned matching image and add it to display */
         foreach($posts as $imagePost)
@@ -83,4 +86,11 @@ function epflGallery($output = '', $attr, $instance){
     return $output;
 }
 
+function register_epfl_gallery() {
+    register_block_type( 'core/gallery', array(
+        'render_callback' => 'epfl_gallery_block',
+    ));
+}
+
+add_action( 'init', 'register_epfl_gallery' );
 ?>


### PR DESCRIPTION
Linked with https://github.com/epfl-si/wp-gutenberg-epfl/pull/188