### PR TITLE
Hide password visibility settings in editor and Clean up unused editor-styles.css

### DIFF
--- a/wp-theme-2018/editor-styles.css
+++ b/wp-theme-2018/editor-styles.css
@@ -1,31 +1,4 @@
-body {
-  background: white;
-  color: #212121;
-  font-size: 18px;
-  font-family: Arial, sans-serif;
-  box-sizing: border-box;
-}
-
-body > p {
-  padding: 0 15px;
-}
-
-.placeholder {
-  background: #fafafa;
-  border: 2px dotted #ccc;
-  box-sizing: border-box;
-  padding: 10px;
-  text-align: center;
-}
-
-.placeholder .content h5 {
-  margin-bottom: 0;
-}
-
-.placeholder .content h3 {
-  margin-top: 0;
-}
-
-.wpview.wpview-wrap {
-  box-sizing: border-box;
+/* Hide the password visibility post option */
+#editor-post-password-0, label[for=editor-post-password-0], #editor-post-password-0-description {
+    display: none;
 }

--- a/wp-theme-2018/functions.php
+++ b/wp-theme-2018/functions.php
@@ -262,10 +262,14 @@ add_image_size( 'thumbnail_square_crop', 300, 300, ['center', 'center'] );
 /**
  * update CSS within admin
  */
-add_action( 'admin_init', 'epfl_add_editor_styles' );
+add_action( 'enqueue_block_editor_assets', 'epfl_add_editor_styles' );
 function epfl_add_editor_styles() {
-	add_theme_support( 'editor-style' );
-	add_editor_style('editor-styles.css');
+    wp_enqueue_style(
+        'editor-styles.css',
+        get_stylesheet_directory_uri() . '/editor-styles.css',
+        array( 'wp-edit-blocks' ),
+        filemtime( dirname( __FILE__ ) . '/editor-styles.css' )
+    );
 }
 
 /**


### PR DESCRIPTION
Strange enough, the old way to load the css was not working : 
add_theme_support( 'editor-style' ); should be add_theme_support( 'editor-styles' );

So some cleanup is welcome I guess, seeing this old content as an artefact of the old theme.