### PR TITLE
[workaround] Make the search functionality to go to the sorry server

### DIFF
--- a/wp-theme-2018/header.php
+++ b/wp-theme-2018/header.php
@@ -194,7 +194,7 @@ class EPFL_Theme2018_Root_Menu_Walker extends Walker_Nav_Menu {
 		<a class="dropdown-toggle" href="#" data-toggle="dropdown">
 			<svg class="icon" aria-hidden="true"><use xlink:href="#icon-search"></use></svg>
 		</a>
-		<form action="https://search.epfl.ch/" class="dropdown-menu border-0 p-0">
+		<form action="https://sorryserver.epfl.ch/" class="dropdown-menu border-0 p-0">
 			<div class="search-form mt-1 input-group">
 				<label for="search" class="sr-only"><?php esc_html_e('Search on the site', 'epfl') ?></label>
 				<input type="text" class="form-control" name="q" placeholder="<?php esc_html_e('Search', 'epfl') ?>" >


### PR DESCRIPTION
This is a quick-and-dirty stopgap to avoid letting non-EPFL visitors hang out to dry with a TCP timeout, during such time that search.epfl.ch is blocked on DIODE (for log4j-ish reasons).