### PR TITLE
[fix] get current language from polylang directly

### DIFF
--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -276,7 +276,7 @@ function get_breadcrumb ($homePageUrl, $urlSite, $lang)
                 $crumb_items = [$crumb_item];
             }
 
-            $current_lang = get_current_language();
+            $current_lang = pll_current_language();
             $homePageUrl = home_url();
             if (!str_ends_with($homePageUrl, '/')) {
                 $homePageUrl = $homePageUrl . '/';

--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -276,7 +276,11 @@ function get_breadcrumb ($homePageUrl, $urlSite, $lang)
                 $crumb_items = [$crumb_item];
             }
 
-            $current_lang = pll_current_language();
+            try {
+                $current_lang = pll_current_language();
+            } catch (Exception $e) {
+                $current_lang = get_current_language();
+            }
             $homePageUrl = home_url();
             if (!str_ends_with($homePageUrl, '/')) {
                 $homePageUrl = $homePageUrl . '/';


### PR DESCRIPTION
All languages different not in ('en', 'fr', 'de') arenot taken by the breadcrum and the english language is given as default: 
`$current_lang = get_current_language();`
where:
`function get_current_language ($default_lang='en') {
	# fetch language
	$allowed_langs = array('en', 'fr', 'de');
	$language = $default_lang;

	/* If Polylang installed */
	if(function_exists('pll_current_language'))
	{
		$current_lang = pll_current_language('slug');
		// Check if current lang is supported. If not, use default lang
		$language = (in_array($current_lang, $allowed_langs)) ? $current_lang : $default_lang;
	}
	return $language;
}`

So the theme for all other languages doens't show the breadcrumb.
A possible solution (it works locally) could be to get directly the current language from polylang but the following commit was made to avoid it:

https://github.com/epfl-si/wp-theme-2018/commit/d4a59401c9ed43662562e640c84a4c16ca3383f0#diff-9c20da344d4de8813e2c317067e55ed3c607be8aacb5d46853594d9999931027

So, should I modify the function get_current_language()? Or create a new one?

