### PR TITLE
[feature](WPN-258) Rename menu-api-siblings to menu-api

### DIFF
--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -197,7 +197,7 @@ function _call_menu_api_microservice($homePageUrl, $urlSite, $lang,$callType): a
     $mainPostPageName = urlencode(get_the_title($current_language_page_id));
     $mainPostPageUrl = get_permalink($current_language_page_id);
 
-    $urlApi = 'http://menu-api-siblings:3001/menus/'.$callType.'/?lang=' . $lang . '&url=' . trailingslashit( $urlSite ) .
+    $urlApi = 'http://menu-api:3001/menus/'.$callType.'/?lang=' . $lang . '&url=' . trailingslashit( $urlSite ) .
         '&pageType=' . get_post_type() .
         ($main_post_page == 0 ? '' : ($mainPostPageName == '' ? '' : '&mainPostPageName=' . $mainPostPageName)) .
         ($main_post_page == 0 ? '' : ($mainPostPageUrl == '' ? '' : '&mainPostPageUrl=' . $mainPostPageUrl)).


### PR DESCRIPTION
Rename menu-api-siblings to menu-api even in the OS3 to make the theme calling the new menu-api container in the OS4 environment