### PR TITLE
[fix] Limit the DNS domains for which we consume the menu-api microservice

### DIFF
--- a/wp-theme-2018/menu_microservice.inc
+++ b/wp-theme-2018/menu_microservice.inc
@@ -5,7 +5,7 @@
  */
 function has_menu_api() {
     $site_url = get_site_url();
-    foreach (["www.epfl.ch", "wpn-test.epfl.ch", "wordpress.localhost"] as $stitchable_domain) {
+    foreach (["www.epfl.ch", "wpn-test.epfl.ch", "wordpress.localhost", "wp-httpd"] as $stitchable_domain) {
         if (str_contains($site_url, $stitchable_domain)) {
             return TRUE;
         }

--- a/wp-theme-2018/menu_microservice.inc
+++ b/wp-theme-2018/menu_microservice.inc
@@ -1,5 +1,18 @@
 <?php
 
+/**
+ * True iff this WordPress consumes the menu microservice.
+ */
+function has_menu_api() {
+    $site_url = get_site_url();
+    foreach (["www.epfl.ch", "wpn-test.epfl.ch", "wordpress.localhost"] as $stitchable_domain) {
+        if (str_contains($site_url, $stitchable_domain)) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 function call_menu_api_microservice($site, $call_type, $post, $item_url = NULL)
 {
     $lang = $site->get_language();

--- a/wp-theme-2018/sidebar.php
+++ b/wp-theme-2018/sidebar.php
@@ -85,24 +85,21 @@ function get_stitched_menus($post)
 
                         $current_item = get_current_item($items);
 
-                        if (has_menu_api()) {
-                            $response = get_stitched_menus($post);
-                            if ($response) {
-                                $siblings = $response['siblings'] ?? [];
-                                $children = $response['children'] ?? [];
-                                foreach($siblings as $crumb_item) {
-                                    render_sidebar_item($crumb_item, $current_item, $children);
-                                }
-                            } else {
-                                wp_nav_menu( array(
-                                    'theme_location' => $EPFL_MENU_LOCATION,
-                                    'menu_class'=> 'nav-menu',
-                                    'container' => 'ul',
-                                    'submenu' => get_the_ID(),
-                                    'submenu_type' => $asideContent
-                                ) );
-
+                        if ( has_menu_api() && ($response = get_stitched_menus($post)) ) {
+                            $siblings = $response['siblings'] ?? [];
+                            $children = $response['children'] ?? [];
+                            foreach($siblings as $crumb_item) {
+                                render_sidebar_item($crumb_item, $current_item, $children);
                             }
+                        } else {
+                            wp_nav_menu( array(
+                                'theme_location' => $EPFL_MENU_LOCATION,
+                                'menu_class'=> 'nav-menu',
+                                'container' => 'ul',
+                                'submenu' => get_the_ID(),
+                                'submenu_type' => $asideContent
+                            ) );
+
                         }
 
                     ?>

--- a/wp-theme-2018/sidebar.php
+++ b/wp-theme-2018/sidebar.php
@@ -85,22 +85,24 @@ function get_stitched_menus($post)
 
                         $current_item = get_current_item($items);
 
-                        $response = get_stitched_menus($post);
-                        if ($response) {
-                            $siblings = $response['siblings'] ?? [];
-                            $children = $response['children'] ?? [];
-                            foreach($siblings as $crumb_item) {
-                                render_sidebar_item($crumb_item, $current_item, $children);
-                            }
-                        } else {
-                            wp_nav_menu( array(
-                                'theme_location' => $EPFL_MENU_LOCATION,
-                                'menu_class'=> 'nav-menu',
-                                'container' => 'ul',
-                                'submenu' => get_the_ID(),
-                                'submenu_type' => $asideContent
-                            ) );
+                        if (has_menu_api()) {
+                            $response = get_stitched_menus($post);
+                            if ($response) {
+                                $siblings = $response['siblings'] ?? [];
+                                $children = $response['children'] ?? [];
+                                foreach($siblings as $crumb_item) {
+                                    render_sidebar_item($crumb_item, $current_item, $children);
+                                }
+                            } else {
+                                wp_nav_menu( array(
+                                    'theme_location' => $EPFL_MENU_LOCATION,
+                                    'menu_class'=> 'nav-menu',
+                                    'container' => 'ul',
+                                    'submenu' => get_the_ID(),
+                                    'submenu_type' => $asideContent
+                                ) );
 
+                            }
                         }
 
                     ?>

--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -156,7 +156,7 @@ function get_rendered_crumb_item($crumb_item, $is_current_item, $siblings_items)
             <a class=\"bread-link\" href=\"{$url}\" title=\"{$title}\">
                 {$title}
             </a>
-            {$siblings}     
+            {$siblings}
         </li>";
     }
 }
@@ -241,21 +241,26 @@ function get_breadcrumb ($site, $post)
                 $crumb_items = [$crumb_item];
             }
 
-            $site = new CurrentSite();
-            $parent_items = get_breadcrumb($site, $post);
+            if (has_menu_api()) {
+                $site = new CurrentSite();
+                $parent_items = get_breadcrumb($site, $post);
 
-            foreach($parent_items as $crumb_item) {
-                $siblings_items = $crumb_item['siblings'] ?? [];
-                $current_item_db_id = $current_item->db_id ?? null;
-                $crumb_item_db_id = $crumb_item['db_id'] ?? null;
-                if ($current_item_db_id && $crumb_item_db_id && (int) $current_item_db_id === (int) $crumb_item_db_id) { // current item ?
-                    $crumbs[] = get_rendered_crumb_item($crumb_item, True, $siblings_items);
-                } else {
-                    $crumbs[] = get_rendered_crumb_item($crumb_item, False, $siblings_items);
+                foreach($parent_items as $crumb_item) {
+                    $siblings_items = $crumb_item['siblings'] ?? [];
+                    $current_item_db_id = $current_item->db_id ?? null;
+                    $crumb_item_db_id = $crumb_item['db_id'] ?? null;
+                    if ($current_item_db_id && $crumb_item_db_id && (int) $current_item_db_id === (int) $crumb_item_db_id) { // current item ?
+                        $crumbs[] = get_rendered_crumb_item($crumb_item, True, $siblings_items);
+                    } else {
+                        $crumbs[] = get_rendered_crumb_item($crumb_item, False, $siblings_items);
+                    }
                 }
-            }
 
-            echo implode('', $crumbs);
+                echo implode('', $crumbs);
+            } else {
+                // TODO: we should give some kind of breadcrumb fallback
+                // for “subdomains-light” theme users.
+            }
             ?>
         </ol>
     </nav>

--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -258,9 +258,21 @@ function get_breadcrumb ($site, $post)
 
                 echo implode('', $crumbs);
             } else {
-                // TODO: we should give some kind of breadcrumb fallback
-                // for “subdomains-light” theme users.
-            }
+                # There is no place like 🏠...
+?>
+            <li class="breadcrumb-item">
+                <a class="bread-link bread-home" href="https://50ans.epfl.ch" title="home">
+                    <svg class="icon" aria-hidden="true"><use xlink:href="#icon-home"></use></svg>
+                </a>
+            </li>
+            <li class="breadcrumb-item expand-links">
+                <button class="btn btn-expand-links" aria-expanded="false" title="Afficher l'intégralité du fil d'Ariane">
+                    <span class="dots" aria-hidden="true">…</span>
+                    <span class="sr-only">Afficher l'intégralité du fil d'Ariane</span>
+                </button>
+            </li>
+<?php
+             }
             ?>
         </ol>
     </nav>


### PR DESCRIPTION
We don't want to burden the menu API microservice (and specifically, lengthen the pod's startup time) for our use cases which don't actually depend on menu stitching.