### PR TITLE
[fix] Breadcrumb for subdomains and template

### DIFF
--- a/wp-theme-2018/menu_microservice.inc
+++ b/wp-theme-2018/menu_microservice.inc
@@ -4,12 +4,8 @@
  * True iff this WordPress consumes the menu microservice.
  */
 function has_menu_api() {
-    $site_url = get_site_url();
-    foreach (["www.epfl.ch", "wpn-test.epfl.ch", "wordpress.localhost", "wp-httpd"] as $stitchable_domain) {
-        if (str_contains($site_url, $stitchable_domain)) {
-            return TRUE;
-        }
-    }
+    if (is_plugin_active('epfl-menus/epfl-menus.php'))
+        return TRUE;
     return FALSE;
 }
 

--- a/wp-theme-2018/menu_microservice.inc
+++ b/wp-theme-2018/menu_microservice.inc
@@ -9,7 +9,7 @@ function has_menu_api() {
     return FALSE;
 }
 
-function call_menu_api_microservice($site, $call_type, $post, $item_url = NULL)
+function call_menu_api_microservice($site, $call_type, $post, $asideContent, $item_url = NULL)
 {
     $lang = $site->get_language();
     $url_site = $item_url ?? $site->get_post_url($post);
@@ -32,7 +32,7 @@ function call_menu_api_microservice($site, $call_type, $post, $item_url = NULL)
     . '&url=' . trailingslashit( $url_site ) . '&pageType=' . get_post_type($post) .
     ($main_post_page == 0 ? '' : ($main_post_page_name == '' ? '' : '&mainPostPageName=' . $main_post_page_name)) .
     ($main_post_page == 0 ? '' : ($main_post_page_url == '' ? '' : '&mainPostPageUrl=' . $main_post_page_url)) .
-    '&postName=' . urlencode(get_the_title($post)) .
+    '&postName=' . urlencode(get_the_title($post)) . '&template=' . $asideContent .
     '&homePageUrl=' . $home_page_url;
 
     $curl = curl_init($url_api);

--- a/wp-theme-2018/sidebar.php
+++ b/wp-theme-2018/sidebar.php
@@ -43,10 +43,10 @@ function render_sidebar_item($crumb_item, $currentPage, $children) {
     }
 }
 
-function get_stitched_menus($post)
+function get_stitched_menus($post, $asideContent)
 {
     $site = new CurrentSite();
-    return call_menu_api_microservice($site, 'getStitchedMenus', $post);
+    return call_menu_api_microservice($site, 'getStitchedMenus', $post, $asideContent);
 }
 
 
@@ -85,7 +85,7 @@ function get_stitched_menus($post)
 
                         $current_item = get_current_item($items);
 
-                        if ( has_menu_api() && ($response = get_stitched_menus($post)) ) {
+                        if ( has_menu_api() && ($response = get_stitched_menus($post, $asideContent)) ) {
                             $siblings = $response['siblings'] ?? [];
                             $children = $response['children'] ?? [];
                             foreach($siblings as $crumb_item) {

--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -200,6 +200,16 @@ function get_breadcrumb ($site, $post)
     }
 }
 
+function render_menu_item ($crumb_item, $current_item) {
+    $siblings_items = $crumb_item['siblings'] ?? [];
+    $current_item_db_id = $current_item->db_id ?? null;
+    $crumb_item_db_id = $crumb_item['db_id'] ?? null;
+    if ($current_item_db_id && $crumb_item_db_id && (int) $current_item_db_id === (int) $crumb_item_db_id) { // current item ?
+        return get_rendered_crumb_item($crumb_item, True, $siblings_items);
+    } else {
+        return get_rendered_crumb_item($crumb_item, False, $siblings_items);
+    }
+}
 ?>
 
 <div class="breadcrumb-container">
@@ -246,33 +256,16 @@ function get_breadcrumb ($site, $post)
                 $parent_items = get_breadcrumb($site, $post);
 
                 foreach($parent_items as $crumb_item) {
-                    $siblings_items = $crumb_item['siblings'] ?? [];
-                    $current_item_db_id = $current_item->db_id ?? null;
-                    $crumb_item_db_id = $crumb_item['db_id'] ?? null;
-                    if ($current_item_db_id && $crumb_item_db_id && (int) $current_item_db_id === (int) $crumb_item_db_id) { // current item ?
-                        $crumbs[] = get_rendered_crumb_item($crumb_item, True, $siblings_items);
-                    } else {
-                        $crumbs[] = get_rendered_crumb_item($crumb_item, False, $siblings_items);
-                    }
+                    $crumbs[] = render_menu_item($crumb_item, $current_item);
                 }
 
-                echo implode('', $crumbs);
             } else {
-                # There is no place like 🏠...
-?>
-            <li class="breadcrumb-item">
-                <a class="bread-link bread-home" href="/" title="home">
-                    <svg class="icon" aria-hidden="true"><use xlink:href="#icon-home"></use></svg>
-                </a>
-            </li>
-            <li class="breadcrumb-item expand-links">
-                <button class="btn btn-expand-links" aria-expanded="false" title="Afficher l'intégralité du fil d'Ariane">
-                    <span class="dots" aria-hidden="true">…</span>
-                    <span class="sr-only">Afficher l'intégralité du fil d'Ariane</span>
-                </button>
-            </li>
-<?php
+                foreach($crumb_items as $crumb_item) {
+                    $crumb_item = (array) $crumb_item;
+                    $crumbs[] = render_menu_item($crumb_item, $current_item);
+                }
              }
+            echo implode('', $crumbs);
             ?>
         </ol>
     </nav>

--- a/wp-theme-2018/template-parts/breadcrumb.php
+++ b/wp-theme-2018/template-parts/breadcrumb.php
@@ -192,7 +192,7 @@ function render_siblings($siblings_items, $crumb_item) {
 
 function get_breadcrumb ($site, $post)
 {
-    $response = call_menu_api_microservice($site, 'breadcrumb', $post);
+    $response = call_menu_api_microservice($site, 'breadcrumb', $post, 'all');
     if ($response && $response['result']) {
         return $response['result'];
     } else {


### PR DESCRIPTION
- Fix the breadcrumb for Inside: now the theme check if the EPFL menu plugin is installed. Is yes, menuApi is consumed for breadcrumb and siblings, otherwise wordpress standard functions.
- Send to menu-api micro service the `template`of the page to show in the sidebar only children, only siblings or both